### PR TITLE
Fix for Isabelle 2025: always read until end of file.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,11 @@ fn chunk_theory(chars: &[char]) -> Vec<Vec<char>> {
         i = k + 1;
     }
 
+    if let Some(k) = read_until_cmd(&chars, i, "end", Some(|s| s == "isabellebody")) {
+        let chunk = Vec::from(&chars[i - 1..k - 1]);
+        res.push(chunk);
+    }
+
     res
 }
 


### PR DESCRIPTION
At the end of each file Isabelle 20205 no longer puts a `\isacommand`/`\isakeywordONE`, but it will still always put `\end{isabellebody}`, so we can scan for that if no further commands are found.